### PR TITLE
Removed language independent way in action 'Smart: Add receivable to quote' as it has API limitation

### DIFF
--- a/Apps.XTRF/Apps.XTRF.csproj
+++ b/Apps.XTRF/Apps.XTRF.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Product>XTRF</Product>
-        <Version>2.2.16</Version>
+        <Version>2.2.17</Version>
         <Description>Translation project management made easy</Description>
         <AssemblyName>Apps.XTRF</AssemblyName>
     </PropertyGroup>

--- a/Apps.XTRF/Classic/Models/Requests/ClassicQuote/AddQuoteReceivableRequest.cs
+++ b/Apps.XTRF/Classic/Models/Requests/ClassicQuote/AddQuoteReceivableRequest.cs
@@ -35,9 +35,6 @@ namespace Apps.XTRF.Classic.Models.Requests.ClassicQuote
         [Display("Language combination number")]
         public string? LanguageCombinationIdNumber { get; set; }
 
-        [Display("Language-independent")]
-        public bool? IsLanguageIndependent { get; set; }
-
         [Display("Source language ID")]
         [DataSource(typeof(LanguageDataHandler))]
         public string? SourceLanguageId { get; set; }

--- a/Apps.XTRF/Smart/Actions/SmartQuoteActions.cs
+++ b/Apps.XTRF/Smart/Actions/SmartQuoteActions.cs
@@ -159,51 +159,32 @@ public class SmartQuoteActions(InvocationContext invocationContext, IFileManagem
         if (input.Units <= 0)
             throw new PluginMisconfigurationException("Units must be greater than zero.");
 
-        var hasLanguageCombination = input.SourceLanguageId != null && input.TargetLanguageId != null;
-        var hasLanguageCombinationNumber = !string.IsNullOrWhiteSpace(input.LanguageCombinationIdNumber);
-        var isLanguageIndependent = input.IsLanguageIndependent == true;
+        var payload = new
+        {
+            languageCombination = input.SourceLanguageId != null && input.TargetLanguageId != null
+                ? new
+                {
+                    sourceLanguageId = ConvertToInt64(input.SourceLanguageId, "Source language"),
+                    targetLanguageId = ConvertToInt64(input.TargetLanguageId, "Target language")
+                }
+                : null,
+            languageCombinationIdNumber = !string.IsNullOrEmpty(input.LanguageCombinationIdNumber)
+                ? input.LanguageCombinationIdNumber
+                : null,
+            jobTypeId = string.IsNullOrWhiteSpace(input.JobTypeId)
+                ? null
+                : ConvertToInt64(input.JobTypeId, "Job type"),
+            type = input.Type ?? "SIMPLE",
+            calculationUnitId = ConvertToInt64(input.CalculationUnitId, "Calculation unit"),
+            quantity = input.Units,
+            rate = input.Rate,
+            rateOrigin = input.Rate.HasValue ? "CUSTOM" : "PRICE_PROFILE",
+            currencyId = string.IsNullOrWhiteSpace(input.CurrencyId) ? null : ConvertToInt64(input.CurrencyId, "Currency"),
+            ignoreMinimumCharge = input.IgnoreMinimumCharge,
+            minimumCharge = input.MinimumCharge,
+            description = input.Description
+        };
 
-        if (!isLanguageIndependent && !hasLanguageCombination && !hasLanguageCombinationNumber)
-            throw new PluginMisconfigurationException(
-                "Provide Source and Target language, Language combination number, or enable Language-independent.");
-
-
-        var payload = new Dictionary<string, object?>();
-
-        if (!isLanguageIndependent && hasLanguageCombination)
-            payload["languageCombination"] = new
-            {
-                sourceLanguageId = ConvertToInt64(input.SourceLanguageId, "Source language"),
-                targetLanguageId = ConvertToInt64(input.TargetLanguageId, "Target language")
-            };
-
-        if (!isLanguageIndependent && hasLanguageCombinationNumber)
-            payload["languageCombinationIdNumber"] = input.LanguageCombinationIdNumber;
-
-        if (!string.IsNullOrWhiteSpace(input.JobTypeId))
-            payload["jobTypeId"] = ConvertToInt64(input.JobTypeId, "Job type");
-
-        payload["type"] = input.Type ?? "SIMPLE";
-        payload["calculationUnitId"] = ConvertToInt64(input.CalculationUnitId, "Calculation unit");
-        payload["quantity"] = input.Units;
-        payload["rateOrigin"] = input.Rate.HasValue ? "CUSTOM" : "PRICE_PROFILE";
-
-        if (input.Rate.HasValue)
-            payload["rate"] = input.Rate.Value;
-
-        if (!string.IsNullOrWhiteSpace(input.CurrencyId))
-            payload["currencyId"] = ConvertToInt64(input.CurrencyId, "Currency");
-
-        if (input.IgnoreMinimumCharge.HasValue)
-            payload["ignoreMinimumCharge"] = input.IgnoreMinimumCharge.Value;
-
-        if (input.MinimumCharge.HasValue)
-            payload["minimumCharge"] = input.MinimumCharge.Value;
-
-        if (!string.IsNullOrWhiteSpace(input.Description))
-            payload["description"] = input.Description;
-        var jsonPayload = System.Text.Json.JsonSerializer.Serialize(payload);
-        Console.WriteLine("Payload: " + jsonPayload);
         var req = new XtrfRequest($"/v2/quotes/{quoteIdentifier.QuoteId}/finance/receivables",
             Method.Post, Creds).WithJsonBody(payload, JsonConfig.Settings);
 

--- a/Tests.XTRF/SmartQuoteActionTests.cs
+++ b/Tests.XTRF/SmartQuoteActionTests.cs
@@ -29,13 +29,14 @@ public class SmartQuoteActionTests : TestBase
     {
         // Arrange
         var action = new SmartQuoteActions(InvocationContext, FileManager);
-        var quote = new QuoteIdentifier { QuoteId = "IEW66UVN25BRDGJQTN2VK7KXZY" };
+        var quote = new QuoteIdentifier { QuoteId = "Z7N3D45P7JCCHE3Z26H2RE7YZ4" };
         var input = new AddQuoteReceivableRequest
         {
-            CalculationUnitId = "15",
-            //JobTypeId= "18",
-            Units = 725,
-            IsLanguageIndependent = true
+            CalculationUnitId = "9",
+            JobTypeId = "1",
+            Units = 2,
+            SourceLanguageId = "74",
+            TargetLanguageId = "98"
         };
 
         // Act


### PR DESCRIPTION
Removed language independent way in action 'Smart: Add receivable to quote' as it has API limitation
